### PR TITLE
Migrate to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # cpp-528-spr-2021
+
+## How to update course website
+
+Welcome to CPP 528! To update the course website to reflect the current semester, please update two files:
+
+* [`index.md`](index.md): to reflect who is teaching CPP 528 and other essential logistics
+    + update the `info` section
+    + update the `instructor` section
+* [`_config.yml`](_config.yml): to ensure the course website points to the correct GitHub repo
+    + update the `author` section
+    + update the `GitHub Configuration` section
+        + specifically the `baseurl` and `course_url`
+            + i.e. from `...-fall-2020` to `...-spr-2021`
+    + update the `github_info` section:
+        + specifically the `website-repo` and `course-repo`
+            + i.e. from `...-fall-2020` to `...-spr-2021`
+            

--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ Welcome to CPP 528! To update the course website to reflect the current semester
     + update the `github_info` section:
         + specifically the `website-repo` and `course-repo`
             + i.e. from `...-fall-2020` to `...-spr-2021`
-            

--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,8 @@
 # COURSE INSTRUCTOR: 
 
 author:
-    name:       Jesse Lecy
-    github:     lecy   # Github username for avatar
+    name:       Cristian E. Nuno
+    github:     cenuno   # Github username for avatar
 
 # calendly app for virtual office hours
 calendly:  ''
@@ -52,15 +52,15 @@ header:
 # GITHUB CONFIGURATIONS 
 
 url :               "https://ds4ps.github.io"
-baseurl:            "/cpp-528-fall-2020"
-course_url:         "http://ds4ps.org/cpp-528-fall-2020/"
+baseurl:            "/cpp-528-spr-2021"
+course_url:         "http://ds4ps.org/cpp-528-spr-2021/"
 title:              DS4PS # don't change this
 
 github_info:
     username:          DS4PS # Github location of the course
     branch:            master
-    website-repo:      cpp-528-fall-2020
-    course-repo:       cpp-528-fall-2020
+    website-repo:      cpp-528-spr-2021
+    course-repo:       cpp-528-spr-2021
 
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@
 # COURSE INSTRUCTOR: 
 
 author:
-    name:       Cristian E. Nuno
+    name:       Cristian E. Nuno # update this
     github:     cenuno   # Github username for avatar
 
 # calendly app for virtual office hours
@@ -52,15 +52,15 @@ header:
 # GITHUB CONFIGURATIONS 
 
 url :               "https://ds4ps.github.io"
-baseurl:            "/cpp-528-spr-2021"
-course_url:         "http://ds4ps.org/cpp-528-spr-2021/"
+baseurl:            "/cpp-528-spr-2021" # update this
+course_url:         "http://ds4ps.org/cpp-528-spr-2021/" # update this
 title:              DS4PS # don't change this
 
 github_info:
     username:          DS4PS # Github location of the course
     branch:            master
-    website-repo:      cpp-528-spr-2021
-    course-repo:       cpp-528-spr-2021
+    website-repo:      cpp-528-spr-2021 # update this
+    course-repo:       cpp-528-spr-2021 # update this
 
 
 

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ info:
  course_number: CPP 528 
  course_level: Graduate 
  course_website: 'https://canvas.asu.edu/courses/70101/'
- course_start_end_dates: March to May, 2021
+ course_start_end_dates: March 8 to April 23, 2021
  course_prerequisites:  
  class_meets_when:  Asynchronous  
  class_meets_where:  'https://asu.zoom.us/meeting/557182841'
@@ -24,7 +24,7 @@ info:
 
 instructor:
 -  name: Cristian E. Nuno
-   title: Manager of Data Engineering / Faculty Associate
+   title: Manager of Data Engineering and Information Systems / Faculty Associate
    email: cenuno@asu.edu   
    office_location: virtual
    website_url: 

--- a/schedule.md
+++ b/schedule.md
@@ -3,31 +3,30 @@ layout: default
 title: Schedule
 
 canvas: 
-  assignment_url: 'https://canvas.asu.edu/courses/70101/assignments'
+  assignment_url: 'https://canvas.asu.edu/courses/82561/assignments'
   
-yellowdig_url: 'https://canvas.asu.edu/courses/70101/assignments/1721192'
+yellowdig_url: 'https://canvas.asu.edu/courses/82561/assignments/2072813'
 
 yellowdig: 
-  post-01: 'Friday, October 16th'
-  post-02: 'Friday, October 23rd'
-  post-03: 'Friday, October 30th'
-  post-04: 'Friday, November 6th' 
-  post-05: 'Friday, November 13th' 
-  post-06: 'Friday, November 20th' 
-  post-07: 'Friday, November 27th' 
+  post-01: 'Friday, March 12'
+  post-02: 'Friday, March 19'
+  post-03: 'Friday, March 26'
+  post-04: 'Friday, April 2' 
+  post-05: 'Friday, April 9' 
+  post-06: 'Friday, April 16' 
+  post-07: 'Friday, April 23' 
   
 
 labs:
-  lab-01:  'Tuesday, October 20th'
-  lab-02:  'Tuesday, October 27th'
-  lab-03:  'Friday, November 6th'
-  lab-04:  'Tuesday, November 10th'
-  lab-05:  'Tuesday, November 17th'
-  lab-06:  'Tuesday, November 24th'
+  lab-01:  'Tuesday, March 16'
+  lab-02:  'Tuesday, March 23'
+  lab-03:  'Friday, March 30'
+  lab-04:  'Tuesday, April 6'
+  lab-05:  'Tuesday, April 13'
   
   
 projects: 
-  website: 'Friday, December 4th'
+  website: 'Friday, April 23'
   
   
 ---
@@ -268,7 +267,7 @@ For your lab assignment this week split the rubric into tasks on your Kanban boa
 
 Let the instructor know when you have your board set up and ready for inspection by submitting the link for your project board. 
 
-[Week 01 Lab Submission Link](https://canvas.asu.edu/courses/70101/assignments/1721185)
+[Week 01 Lab Submission Link](https://canvas.asu.edu/courses/82561/assignments/2072803)
 
 
 <br>


### PR DESCRIPTION
* Add explicit instructions on how to update course website to point to this repository
* Update syllabus with updated canvas and yellowdig links