### PR TITLE
Call renv::restore first followed by here::here

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thanks to the [`renv`](https://rstudio.github.io/renv/index.html) package, you c
 
 ```r
 # restore a project's dependencies from the renv.lock file (located in the root directory)
-here::here(renv::restore())
+renv::restore(here::here())
 ```
 
 For more context, here's what happens under the hood when [`renv::restore()`](https://rstudio.github.io/renv/reference/restore.html#library) is called:


### PR DESCRIPTION
Left as is, `renv::restore()` fails because `here::here()` only generates a file path.

This PR successfully calls `renv::restore()` and uses `here::here()` so that `renv` can search for the `renv.lock` file within the root directory via `here::here()`, regardless of where the user is within the directory.